### PR TITLE
Allow automatic commenting and improve paragraph fill behavior

### DIFF
--- a/markless.el
+++ b/markless.el
@@ -355,7 +355,9 @@ Marks PRE and POST as markup and the content with PROP."
                              nil nil nil nil
                              (font-lock-multiline . t)))
   (setq-local flyspell-generic-check-word-predicate
-              #'markless-at-word-p))
+              #'markless-at-word-p)
+  (setq-local comment-start ";")
+  (setq-local comment-start-skip ";+ "))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.mess" . markless-mode))

--- a/markless.el
+++ b/markless.el
@@ -357,7 +357,31 @@ Marks PRE and POST as markup and the content with PROP."
   (setq-local flyspell-generic-check-word-predicate
               #'markless-at-word-p)
   (setq-local comment-start ";")
-  (setq-local comment-start-skip ";+ "))
+  (setq-local comment-start-skip ";+ ")
+  (setq-local paragraph-start
+              (mapconcat #'identity
+                         '(
+                           "\f" ; linefeed
+                           "[ \t\f]*$" ; whitespace-only line
+                           "[ \t]*\|[ \t\f]*$" ; empty blockquote line
+                           "[ \t]*-[ \t]+" ; unordered list item
+                           "[ \t]*[0-9]+\\.[ \t]+" ; ordered list item
+                           "\\[[0-9]+\\]" ; footnote
+                           )
+                         "\\|"))
+  (setq-local paragraph-separate
+              (mapconcat #'identity
+                         '(
+                           "\\([ \t]*\\|| \\)+~[ \t]*" ; blockquote header
+                           "\\([ \t]*\\|| \\)+$" ; empty (blockquote) line
+                           "\\([ \t]*\\|| \\)+#+" ; heading
+                           "\\([ \t]*\\|| \\)+! " ; instruction
+                           "\\([ \t]*\\|| \\)+;+ " ; comment
+                           "\\([ \t]*\\|| \\)+\\[ " ; embed
+                           "\\([ \t]*\\|| \\)+==+" ; horizontal rule
+                           "\\([ \t]*\\|| \\)+[\d+] " ; footnote
+                           )
+                         "\\|")))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.mess" . markless-mode))


### PR DESCRIPTION
Setting `comment-start` makes `M-;` work (mostly) properly. I haven't found a way to make it always open a new line, so when you use it while on an existing line it will start a comment at the end of that line, which is not valid.

Setting `paragraph-start` and `paragraph-separate` makes life more bearable for those of us who like to

```markless
! set line-break-mode hide
```

I am not 100% sure these settings are completely correct, but they seem to hold up in my testing.