### PR TITLE
Updated to support double single-quotes

### DIFF
--- a/markless.el
+++ b/markless.el
@@ -184,10 +184,10 @@ Marks PRE and POST as markup and the content with PROP."
        (markless-inline-directive "<-" "->" 'markless-strikethrough-face)
        (markless-inline-directive "v(" ")" '(display ((raise -0.2) (height 0.9))))
        (markless-inline-directive "^(" ")" '(display ((raise +0.2) (height 0.9))))
-       (when (markless-match "\"")
+       (when (or (markless-match "''") (markless-match "\"")) ;; Note: Double quotes are deprecated.
          (let ((start (point)))
            (forward-char)
-           (when (markless-match-inline "\"(")
+           (when (or (markless-match-inline "''(") (markless-match-inline "\"("))
              (markless-mark start (1+ start) 'markless-markup-face)
              (let ((end (point)))
                (re-search-forward ")" (point-at-eol) t)


### PR DESCRIPTION
Hopefully this is enough to support the new format.

> the compound syntax is two single quotes, not a double quote. so ' ' f o o ' ' ( b a r )
> the doublequote syntax will still work, but it's deprecated

